### PR TITLE
feat(design): add foundations.pen with Design Tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ npm run lint
 - **Framework**: Next.js 15 (App Router)
 - **言語**: TypeScript
 - **スタイリング**: Tailwind CSS + CSS-in-JS
-- **フォント**: Lato (Google Fonts)
+- **フォント**: Source Sans 3 + Noto Sans JP (Google Fonts) ※リデザイン後
 - **アイコン**: Phosphor Icons, Lucide React, FontAwesome
 - **アナリティクス**: Google Tag Manager
 

--- a/design/foundations.pen
+++ b/design/foundations.pen
@@ -1,0 +1,280 @@
+{
+  "version": "1.0",
+  "themes": {
+    "mode": ["light", "dark"]
+  },
+  "variables": {
+    "background": {
+      "type": "color",
+      "value": [
+        {"value": "#FFFFFF", "theme": {"mode": "light"}},
+        {"value": "#0A0A0A", "theme": {"mode": "dark"}}
+      ]
+    },
+    "foreground": {
+      "type": "color",
+      "value": [
+        {"value": "#0A0A0A", "theme": {"mode": "light"}},
+        {"value": "#FAFAFA", "theme": {"mode": "dark"}}
+      ]
+    },
+    "muted": {
+      "type": "color",
+      "value": [
+        {"value": "#F5F5F5", "theme": {"mode": "light"}},
+        {"value": "#262626", "theme": {"mode": "dark"}}
+      ]
+    },
+    "muted-foreground": {
+      "type": "color",
+      "value": [
+        {"value": "#737373", "theme": {"mode": "light"}},
+        {"value": "#A3A3A3", "theme": {"mode": "dark"}}
+      ]
+    },
+    "border": {
+      "type": "color",
+      "value": [
+        {"value": "#E5E5E5", "theme": {"mode": "light"}},
+        {"value": "#262626", "theme": {"mode": "dark"}}
+      ]
+    },
+    "font-primary": {
+      "type": "string",
+      "value": "Source Sans 3, Noto Sans JP, sans-serif"
+    },
+    "font-weight-base": {
+      "type": "number",
+      "value": 300
+    },
+    "font-size-body": {
+      "type": "number",
+      "value": 18
+    },
+    "line-height-body": {
+      "type": "number",
+      "value": 1.8
+    }
+  },
+  "children": [
+    {
+      "type": "frame",
+      "id": "7Em8x",
+      "name": "Foundations",
+      "x": 0,
+      "y": 0,
+      "width": 800,
+      "height": "fit_content(800)",
+      "fill": "$background",
+      "layout": "vertical",
+      "gap": 40,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "aHUiC",
+          "name": "titleText",
+          "content": "synsk.me Design Foundations",
+          "fill": "$foreground",
+          "fontFamily": "Inter",
+          "fontSize": 32,
+          "fontWeight": "300"
+        },
+        {
+          "type": "frame",
+          "id": "HLS3U",
+          "name": "Colors",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "4Ztc7",
+              "name": "colorsTitle",
+              "content": "COLORS",
+              "fill": "$muted-foreground",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "letterSpacing": 0.1
+            },
+            {
+              "type": "text",
+              "id": "7eZVH",
+              "name": "colorsDesc",
+              "content": "モノクロファースト: 色に頼らない情報設計を行う。Neutral Grayを採用。",
+              "fill": "$muted-foreground",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 720
+            },
+            {
+              "type": "frame",
+              "id": "fajQs",
+              "name": "colorPalette",
+              "width": "fill_container",
+              "layout": "horizontal",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wl0qJ",
+                  "name": "bgSwatch",
+                  "width": 120,
+                  "height": 80,
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "3EbLc",
+                      "name": "bgColor",
+                      "width": "fill_container",
+                      "height": 48,
+                      "fill": "$background",
+                      "cornerRadius": 8,
+                      "stroke": {"fill": "$border", "thickness": 1}
+                    },
+                    {
+                      "type": "text",
+                      "id": "eTWl2",
+                      "name": "bgLabel",
+                      "content": "background",
+                      "fill": "$muted-foreground",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "skDur",
+                  "name": "fgSwatch",
+                  "width": 120,
+                  "height": 80,
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yzb6m",
+                      "name": "fgColor",
+                      "width": "fill_container",
+                      "height": 48,
+                      "fill": "$foreground",
+                      "cornerRadius": 8
+                    },
+                    {
+                      "type": "text",
+                      "id": "r8xOO",
+                      "name": "fgLabel",
+                      "content": "foreground",
+                      "fill": "$muted-foreground",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vdQuf",
+                  "name": "mutedSwatch",
+                  "width": 120,
+                  "height": 80,
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iOwwV",
+                      "name": "mutedColor",
+                      "width": "fill_container",
+                      "height": 48,
+                      "fill": "$muted",
+                      "cornerRadius": 8,
+                      "stroke": {"fill": "$border", "thickness": 1}
+                    },
+                    {
+                      "type": "text",
+                      "id": "9u6Op",
+                      "name": "mutedLabel",
+                      "content": "muted",
+                      "fill": "$muted-foreground",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xEACM",
+                  "name": "mutedFgSwatch",
+                  "width": 120,
+                  "height": 80,
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rF7nn",
+                      "name": "mutedFgColor",
+                      "width": "fill_container",
+                      "height": 48,
+                      "fill": "$muted-foreground",
+                      "cornerRadius": 8
+                    },
+                    {
+                      "type": "text",
+                      "id": "c6dSb",
+                      "name": "mutedFgLabel",
+                      "content": "muted-foreground",
+                      "fill": "$muted-foreground",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "o3iLM",
+                  "name": "borderSwatch",
+                  "width": 120,
+                  "height": 80,
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gwESC",
+                      "name": "borderColor",
+                      "width": "fill_container",
+                      "height": 48,
+                      "fill": "$border",
+                      "cornerRadius": 8
+                    },
+                    {
+                      "type": "text",
+                      "id": "7KSON",
+                      "name": "borderLabel",
+                      "content": "border",
+                      "fill": "$muted-foreground",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/design/foundations.pen
+++ b/design/foundations.pen
@@ -4,277 +4,55 @@
     "mode": ["light", "dark"]
   },
   "variables": {
-    "background": {
+    "--background": {
       "type": "color",
       "value": [
         {"value": "#FFFFFF", "theme": {"mode": "light"}},
         {"value": "#0A0A0A", "theme": {"mode": "dark"}}
       ]
     },
-    "foreground": {
+    "--foreground": {
       "type": "color",
       "value": [
         {"value": "#0A0A0A", "theme": {"mode": "light"}},
         {"value": "#FAFAFA", "theme": {"mode": "dark"}}
       ]
     },
-    "muted": {
+    "--muted": {
       "type": "color",
       "value": [
         {"value": "#F5F5F5", "theme": {"mode": "light"}},
         {"value": "#262626", "theme": {"mode": "dark"}}
       ]
     },
-    "muted-foreground": {
+    "--muted-foreground": {
       "type": "color",
       "value": [
         {"value": "#737373", "theme": {"mode": "light"}},
         {"value": "#A3A3A3", "theme": {"mode": "dark"}}
       ]
     },
-    "border": {
+    "--border": {
       "type": "color",
       "value": [
         {"value": "#E5E5E5", "theme": {"mode": "light"}},
         {"value": "#262626", "theme": {"mode": "dark"}}
       ]
     },
-    "font-primary": {
-      "type": "string",
-      "value": "Source Sans 3, Noto Sans JP, sans-serif"
-    },
-    "font-weight-base": {
-      "type": "number",
-      "value": 300
-    },
-    "font-size-body": {
-      "type": "number",
-      "value": 18
-    },
-    "line-height-body": {
-      "type": "number",
-      "value": 1.8
-    }
+    "--font-primary": {"type": "string", "value": "Source Sans 3"},
+    "--font-secondary": {"type": "string", "value": "Noto Sans JP"},
+    "--font-weight-light": {"type": "number", "value": 300},
+    "--font-size-body": {"type": "number", "value": 18},
+    "--font-size-small": {"type": "number", "value": 14},
+    "--font-size-caption": {"type": "number", "value": 12},
+    "--font-size-h1": {"type": "number", "value": 34},
+    "--font-size-h2": {"type": "number", "value": 26},
+    "--line-height-body": {"type": "number", "value": 1.8},
+    "--spacing-xs": {"type": "number", "value": 8},
+    "--spacing-sm": {"type": "number", "value": 16},
+    "--spacing-md": {"type": "number", "value": 24},
+    "--spacing-lg": {"type": "number", "value": 48},
+    "--spacing-xl": {"type": "number", "value": 96}
   },
-  "children": [
-    {
-      "type": "frame",
-      "id": "7Em8x",
-      "name": "Foundations",
-      "x": 0,
-      "y": 0,
-      "width": 800,
-      "height": "fit_content(800)",
-      "fill": "$background",
-      "layout": "vertical",
-      "gap": 40,
-      "padding": 40,
-      "children": [
-        {
-          "type": "text",
-          "id": "aHUiC",
-          "name": "titleText",
-          "content": "synsk.me Design Foundations",
-          "fill": "$foreground",
-          "fontFamily": "Inter",
-          "fontSize": 32,
-          "fontWeight": "300"
-        },
-        {
-          "type": "frame",
-          "id": "HLS3U",
-          "name": "Colors",
-          "width": "fill_container",
-          "layout": "vertical",
-          "gap": 16,
-          "children": [
-            {
-              "type": "text",
-              "id": "4Ztc7",
-              "name": "colorsTitle",
-              "content": "COLORS",
-              "fill": "$muted-foreground",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "letterSpacing": 0.1
-            },
-            {
-              "type": "text",
-              "id": "7eZVH",
-              "name": "colorsDesc",
-              "content": "モノクロファースト: 色に頼らない情報設計を行う。Neutral Grayを採用。",
-              "fill": "$muted-foreground",
-              "fontFamily": "Inter",
-              "fontSize": 14,
-              "fontWeight": "normal",
-              "textGrowth": "fixed-width",
-              "width": 720
-            },
-            {
-              "type": "frame",
-              "id": "fajQs",
-              "name": "colorPalette",
-              "width": "fill_container",
-              "layout": "horizontal",
-              "gap": 16,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "wl0qJ",
-                  "name": "bgSwatch",
-                  "width": 120,
-                  "height": 80,
-                  "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "3EbLc",
-                      "name": "bgColor",
-                      "width": "fill_container",
-                      "height": 48,
-                      "fill": "$background",
-                      "cornerRadius": 8,
-                      "stroke": {"fill": "$border", "thickness": 1}
-                    },
-                    {
-                      "type": "text",
-                      "id": "eTWl2",
-                      "name": "bgLabel",
-                      "content": "background",
-                      "fill": "$muted-foreground",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "skDur",
-                  "name": "fgSwatch",
-                  "width": 120,
-                  "height": 80,
-                  "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "yzb6m",
-                      "name": "fgColor",
-                      "width": "fill_container",
-                      "height": 48,
-                      "fill": "$foreground",
-                      "cornerRadius": 8
-                    },
-                    {
-                      "type": "text",
-                      "id": "r8xOO",
-                      "name": "fgLabel",
-                      "content": "foreground",
-                      "fill": "$muted-foreground",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "vdQuf",
-                  "name": "mutedSwatch",
-                  "width": 120,
-                  "height": 80,
-                  "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "iOwwV",
-                      "name": "mutedColor",
-                      "width": "fill_container",
-                      "height": 48,
-                      "fill": "$muted",
-                      "cornerRadius": 8,
-                      "stroke": {"fill": "$border", "thickness": 1}
-                    },
-                    {
-                      "type": "text",
-                      "id": "9u6Op",
-                      "name": "mutedLabel",
-                      "content": "muted",
-                      "fill": "$muted-foreground",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "xEACM",
-                  "name": "mutedFgSwatch",
-                  "width": 120,
-                  "height": 80,
-                  "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "rF7nn",
-                      "name": "mutedFgColor",
-                      "width": "fill_container",
-                      "height": 48,
-                      "fill": "$muted-foreground",
-                      "cornerRadius": 8
-                    },
-                    {
-                      "type": "text",
-                      "id": "c6dSb",
-                      "name": "mutedFgLabel",
-                      "content": "muted-foreground",
-                      "fill": "$muted-foreground",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "o3iLM",
-                  "name": "borderSwatch",
-                  "width": 120,
-                  "height": 80,
-                  "layout": "vertical",
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "gwESC",
-                      "name": "borderColor",
-                      "width": "fill_container",
-                      "height": 48,
-                      "fill": "$border",
-                      "cornerRadius": 8
-                    },
-                    {
-                      "type": "text",
-                      "id": "7KSON",
-                      "name": "borderLabel",
-                      "content": "border",
-                      "fill": "$muted-foreground",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "children": [{"children":[{"content":"Design Foundations","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":48,"fontWeight":"300","id":"VwGLs","letterSpacing":-0.5,"name":"title","type":"text"},{"content":"synsk.me の視覚言語基盤","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"RavMZ","name":"subtitle","type":"text"},{"children":[{"content":"Colors","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":28,"fontWeight":"300","id":"Uro3a","name":"colorsTitle","type":"text"},{"content":"モノクロファースト: 色に頼らない情報設計。Neutral Gray で構造を固める。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"2btAj","lineHeight":1.6,"name":"colorsDesc","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"children":[{"content":"LIGHT MODE","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"LEDSl","letterSpacing":1.5,"name":"lightLabel","type":"text"},{"children":[{"children":[{"cornerRadius":8,"fill":"#FFFFFF","height":64,"id":"fqTRz","name":"bgSwatch","stroke":{"align":"inside","fill":"#E5E5E5","thickness":1},"type":"frame","width":"fill_container"},{"content":"background","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"u4lHg","name":"bgLabel","type":"text"},{"content":"#FFFFFF","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"QO0FP","name":"bgValue","type":"text"}],"gap":8,"id":"Cq5tP","layout":"vertical","name":"bg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#0A0A0A","height":64,"id":"PfI1Y","name":"fgSwatch","type":"frame","width":"fill_container"},{"content":"foreground","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"18mWU","name":"fgLabel","type":"text"},{"content":"#0A0A0A","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"3TH1t","name":"fgValue","type":"text"}],"gap":8,"id":"jhqsz","layout":"vertical","name":"fg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#F5F5F5","height":64,"id":"8GWQf","name":"mutedSwatch","stroke":{"align":"inside","fill":"#E5E5E5","thickness":1},"type":"frame","width":"fill_container"},{"content":"muted","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"Muo7V","name":"mutedLabel","type":"text"},{"content":"#F5F5F5","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"8h66z","name":"mutedValue","type":"text"}],"gap":8,"id":"HfyzF","layout":"vertical","name":"muted","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#737373","height":64,"id":"doHZN","name":"mutedFgSwatch","type":"frame","width":"fill_container"},{"content":"muted-foreground","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"e61QD","name":"mutedFgLabel","type":"text"},{"content":"#737373","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"b1v8V","name":"mutedFgValue","type":"text"}],"gap":8,"id":"nOaMs","layout":"vertical","name":"mutedFg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#E5E5E5","height":64,"id":"prGz6","name":"borderSwatch","stroke":{"align":"inside","fill":"#D4D4D4","thickness":1},"type":"frame","width":"fill_container"},{"content":"border","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"rWsEI","name":"borderLabel","type":"text"},{"content":"#E5E5E5","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"hunBw","name":"borderValue","type":"text"}],"gap":8,"id":"0g0EH","layout":"vertical","name":"border","type":"frame","width":"fill_container"}],"gap":16,"id":"s5eWz","name":"lightSwatches","type":"frame","width":"fill_container"},{"content":"DARK MODE","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"2qOO7","letterSpacing":1.5,"name":"darkLabel","type":"text"},{"children":[{"children":[{"cornerRadius":8,"fill":"#0A0A0A","height":64,"id":"5H5Xo","name":"dbgSwatch","stroke":{"align":"inside","fill":"#262626","thickness":1},"type":"frame","width":"fill_container"},{"content":"background","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"z0681","name":"dbgLabel","type":"text"},{"content":"#0A0A0A","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"ST4ny","name":"dbgValue","type":"text"}],"gap":8,"id":"oEc3O","layout":"vertical","name":"dbg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#FAFAFA","height":64,"id":"6sRn5","name":"dfgSwatch","type":"frame","width":"fill_container"},{"content":"foreground","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"w9Yvf","name":"dfgLabel","type":"text"},{"content":"#FAFAFA","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"QWNG0","name":"dfgValue","type":"text"}],"gap":8,"id":"k5ZkW","layout":"vertical","name":"dfg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#262626","height":64,"id":"14t4Z","name":"dmutedSwatch","stroke":{"align":"inside","fill":"#404040","thickness":1},"type":"frame","width":"fill_container"},{"content":"muted","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"jcuMw","name":"dmutedLabel","type":"text"},{"content":"#262626","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"oj5Lq","name":"dmutedValue","type":"text"}],"gap":8,"id":"IPDHe","layout":"vertical","name":"dmuted","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#A3A3A3","height":64,"id":"D1eXb","name":"dmutedFgSwatch","type":"frame","width":"fill_container"},{"content":"muted-foreground","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"RN7x7","name":"dmutedFgLabel","type":"text"},{"content":"#A3A3A3","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"eIodb","name":"dmutedFgValue","type":"text"}],"gap":8,"id":"MVonb","layout":"vertical","name":"dmutedFg","type":"frame","width":"fill_container"},{"children":[{"cornerRadius":8,"fill":"#262626","height":64,"id":"1fRph","name":"dborderSwatch","stroke":{"align":"inside","fill":"#404040","thickness":1},"type":"frame","width":"fill_container"},{"content":"border","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"vwLta","name":"dborderLabel","type":"text"},{"content":"#262626","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"F1XYu","name":"dborderValue","type":"text"}],"gap":8,"id":"RrxN3","layout":"vertical","name":"dborder","type":"frame","width":"fill_container"}],"gap":16,"id":"NLlNM","name":"darkSwatches","type":"frame","width":"fill_container"}],"gap":32,"id":"2WTgP","layout":"vertical","name":"Swatches","type":"frame","width":"fill_container"}],"gap":24,"id":"fj4np","layout":"vertical","name":"Colors Section","type":"frame","width":"fill_container"},{"children":[{"content":"Typography","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":28,"fontWeight":"300","id":"Zup38","name":"typoTitle","type":"text"},{"content":"囁くような軽やかさ: Light 300 ウェイトで視覚的な軽さを実現。文字が主張せず、静かに語りかける。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"rOEHi","lineHeight":1.6,"name":"typoDesc","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"children":[{"children":[{"content":"PRIMARY","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"zbosL","letterSpacing":1.5,"name":"primaryLabel","type":"text"},{"content":"Source Sans 3","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":24,"fontWeight":"300","id":"dausU","name":"primaryName","type":"text"},{"content":"Light 300 · 英語","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"gI9c3","name":"primaryMeta","type":"text"}],"gap":12,"id":"q05BD","layout":"vertical","name":"primaryFont","type":"frame","width":"fill_container"},{"children":[{"content":"SECONDARY","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"DVWzC","letterSpacing":1.5,"name":"secondaryLabel","type":"text"},{"content":"Noto Sans JP","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":24,"fontWeight":"300","id":"MZiLC","name":"secondaryName","type":"text"},{"content":"Light 300 · 日本語","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"RzqMm","name":"secondaryMeta","type":"text"}],"gap":12,"id":"EEo0r","layout":"vertical","name":"secondaryFont","type":"frame","width":"fill_container"}],"gap":32,"id":"e0Ffj","name":"fontInfo","type":"frame","width":"fill_container"},{"children":[{"content":"TYPE SCALE","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"96aJX","letterSpacing":1.5,"name":"scaleLabel","type":"text"},{"children":[{"content":"Heading 1 見出し","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":34,"fontWeight":"300","id":"uo9pm","lineHeight":1.3,"name":"h1Text","type":"text"},{"content":"34px · line-height 1.3","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"W7Ycz","name":"h1Meta","type":"text"}],"gap":4,"id":"SIBMS","layout":"vertical","name":"h1Sample","type":"frame","width":"fill_container"},{"children":[{"content":"Heading 2 セクション","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":26,"fontWeight":"300","id":"nY6rC","lineHeight":1.4,"name":"h2Text","type":"text"},{"content":"26px · line-height 1.4","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"tW6X4","name":"h2Meta","type":"text"}],"gap":4,"id":"OLnct","layout":"vertical","name":"h2Sample","type":"frame","width":"fill_container"},{"children":[{"content":"Body text 本文テキスト。余白と呼吸感を大切にした、読みやすい文章。","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"dEMBq","lineHeight":1.8,"name":"bodyText","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"content":"18px · line-height 1.8","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"smPDt","name":"bodyMeta","type":"text"}],"gap":4,"id":"3ckT9","layout":"vertical","name":"bodySample","type":"frame","width":"fill_container"},{"children":[{"content":"Small text 補足テキスト","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"iuqz6","lineHeight":1.6,"name":"smallText","type":"text"},{"content":"14px · line-height 1.6","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"HstFI","name":"smallMeta","type":"text"}],"gap":4,"id":"mDY2E","layout":"vertical","name":"smallSample","type":"frame","width":"fill_container"},{"children":[{"content":"Caption キャプション","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":12,"fontWeight":"300","id":"nSXo5","lineHeight":1.5,"name":"captionText","type":"text"},{"content":"12px · line-height 1.5","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"T1SvN","name":"captionMeta","type":"text"}],"gap":4,"id":"2H6Kw","layout":"vertical","name":"captionSample","type":"frame","width":"fill_container"}],"gap":24,"id":"jkGRR","layout":"vertical","name":"Type Scale","padding":[24,0,0,0],"type":"frame","width":"fill_container"}],"gap":24,"id":"T5oYP","layout":"vertical","name":"Typography Section","type":"frame","width":"fill_container"},{"children":[{"content":"Spacing","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":28,"fontWeight":"300","id":"OiMfA","name":"spacingTitle","type":"text"},{"content":"余白 over 密度: 8px ベースのゆったりとしたスケール。呼吸感を大切にした余白設計。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"s7TKb","lineHeight":1.6,"name":"spacingDesc","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"content":"SCALE","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"xnXEh","letterSpacing":1.5,"name":"scaleLabel","type":"text"},{"children":[{"alignItems":"center","children":[{"cornerRadius":2,"fill":"$--foreground","height":24,"id":"KYogH","name":"xsBar","type":"frame","width":8},{"children":[{"content":"xs","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"Dl4Ye","name":"xsLabel","type":"text"},{"content":"8px","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"S1m14","name":"xsValue","type":"text"}],"gap":2,"id":"wzsPK","layout":"vertical","name":"xsInfo","type":"frame"}],"gap":16,"id":"qDIVo","name":"xs","type":"frame","width":"fill_container"},{"alignItems":"center","children":[{"cornerRadius":2,"fill":"$--foreground","height":24,"id":"0kAmB","name":"smBar","type":"frame","width":16},{"children":[{"content":"sm","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"Jv988","name":"smLabel","type":"text"},{"content":"16px","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"xcCIG","name":"smValue","type":"text"}],"gap":2,"id":"KKAoF","layout":"vertical","name":"smInfo","type":"frame"}],"gap":16,"id":"bu5vz","name":"sm","type":"frame","width":"fill_container"},{"alignItems":"center","children":[{"cornerRadius":2,"fill":"$--foreground","height":24,"id":"dxZto","name":"mdBar","type":"frame","width":24},{"children":[{"content":"md","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"PhtKW","name":"mdLabel","type":"text"},{"content":"24px","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"GSpuj","name":"mdValue","type":"text"}],"gap":2,"id":"PaU9K","layout":"vertical","name":"mdInfo","type":"frame"}],"gap":16,"id":"ijeiV","name":"md","type":"frame","width":"fill_container"},{"alignItems":"center","children":[{"cornerRadius":2,"fill":"$--foreground","height":24,"id":"Kk2Ht","name":"lgBar","type":"frame","width":48},{"children":[{"content":"lg","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"TPm3L","name":"lgLabel","type":"text"},{"content":"48px","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"DDDcw","name":"lgValue","type":"text"}],"gap":2,"id":"n4gof","layout":"vertical","name":"lgInfo","type":"frame"}],"gap":16,"id":"JHFiw","name":"lg","type":"frame","width":"fill_container"},{"alignItems":"center","children":[{"cornerRadius":2,"fill":"$--foreground","height":24,"id":"ba6Zf","name":"xlBar","type":"frame","width":96},{"children":[{"content":"xl","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"PT8mo","name":"xlLabel","type":"text"},{"content":"96px","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"Qkaft","name":"xlValue","type":"text"}],"gap":2,"id":"YDym8","layout":"vertical","name":"xlInfo","type":"frame"}],"gap":16,"id":"CQ65o","name":"xl","type":"frame","width":"fill_container"}],"gap":16,"id":"zO4Gu","layout":"vertical","name":"scaleContainer","type":"frame","width":"fill_container"},{"content":"USAGE","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"SNEqX","letterSpacing":1.5,"name":"usageLabel","type":"text"},{"children":[{"content":"xs (8px): アイコンとテキストの間、インライン要素間","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"JkVIa","name":"usage1","type":"text"},{"content":"sm (16px): フォーム要素間、リストアイテム間","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"WqnOP","name":"usage2","type":"text"},{"content":"md (24px): カード内パディング、コンポーネント間","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"RWcAM","name":"usage3","type":"text"},{"content":"lg (48px): セクション間、大きなコンポーネント間","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"lR95q","name":"usage4","type":"text"},{"content":"xl (96px): ページセクション間、ヒーロー領域","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"7BLsI","name":"usage5","type":"text"}],"gap":8,"id":"9CjL9","layout":"vertical","name":"usageContainer","type":"frame","width":"fill_container"}],"gap":24,"id":"JW5AM","layout":"vertical","name":"Spacing Section","type":"frame","width":"fill_container"}],"fill":"$--background","gap":64,"id":"9ghIy","layout":"vertical","name":"Design Foundations","padding":48,"type":"frame","width":960,"x":0,"y":0},{"children":[{"content":"Spacing Examples","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":32,"fontWeight":"300","id":"eQ4q8","name":"sampleTitle","type":"text"},{"content":"VISION.md のコンテンツを使用したレイアウトサンプル","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"FimPR","name":"sampleDesc","type":"text"},{"children":[{"content":"xl (96px) PADDING","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":10,"id":"CUUfH","letterSpacing":1.5,"name":"heroLabel","type":"text"},{"content":"synsk.me","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":34,"fontWeight":"300","id":"5MmXn","lineHeight":1.3,"name":"heroTitle","type":"text"},{"content":"一緒に奏でて、あなたの中にあるものを形にする","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"xnMbX","lineHeight":1.8,"name":"heroSub","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"cornerRadius":8,"fill":"$--muted","gap":24,"id":"I6RQR","layout":"vertical","name":"Hero Section","padding":96,"type":"frame","width":"fill_container"},{"children":[{"content":"md (24px) PADDING · sm (16px) GAP","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":10,"id":"XksRR","letterSpacing":1.5,"name":"cardLabel","type":"text"},{"content":"How It Works","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"VnazR","name":"cardTitle","type":"text"},{"children":[{"alignItems":"center","children":[{"content":"1.","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"IRLCS","name":"item1Num","type":"text"},{"content":"コンタクト: サイトからご連絡ください","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"SvSPL","name":"item1Text","type":"text"}],"gap":8,"id":"7DiP0","name":"item1","type":"frame"},{"alignItems":"center","children":[{"content":"2.","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"9rBhH","name":"item2Num","type":"text"},{"content":"対話: まずは話を聞かせてください","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"875Cq","name":"item2Text","type":"text"}],"gap":8,"id":"jRu5v","name":"item2","type":"frame"},{"alignItems":"center","children":[{"content":"3.","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":14,"fontWeight":"300","id":"fS0gx","name":"item3Num","type":"text"},{"content":"セッション: 一緒に考え、実験します","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"SD6yA","name":"item3Text","type":"text"}],"gap":8,"id":"zdcpD","name":"item3","type":"frame"}],"gap":16,"id":"5AMw2","layout":"vertical","name":"cardList","type":"frame","width":"fill_container"},{"content":"↑ xs (8px) icon-text gap","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":10,"fontWeight":"300","id":"fGCch","name":"itemNote","type":"text"}],"cornerRadius":8,"fill":"$--background","gap":16,"id":"0l4pc","layout":"vertical","name":"Card Component","padding":24,"stroke":{"align":"inside","fill":"$--border","thickness":1},"type":"frame","width":"fill_container"},{"children":[{"content":"lg (48px) SECTION GAP","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":10,"id":"d4t5E","letterSpacing":1.5,"name":"secLabel","type":"text"},{"children":[{"content":"Problem","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"KF6Gy","name":"sec1Title","type":"text"},{"content":"「やりたいこと」はあるけれど、どう形にすればいいかわからない。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"CEF7X","lineHeight":1.6,"name":"sec1Text","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":8,"id":"VoTI9","layout":"vertical","name":"sec1","type":"frame","width":"fill_container"},{"children":[{"content":"Solution","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"PYFvT","name":"sec2Title","type":"text"},{"content":"対話から始め、実験しながら見つけ、技術とデザインで具現化する。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"PNoRc","lineHeight":1.6,"name":"sec2Text","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":8,"id":"j9d5V","layout":"vertical","name":"sec2","type":"frame","width":"fill_container"}],"gap":48,"id":"xRUZZ","layout":"vertical","name":"Section Gap","type":"frame","width":"fill_container"}],"fill":"$--background","gap":48,"id":"G04jQ","layout":"vertical","name":"Spacing Examples","padding":48,"type":"frame","width":600,"x":1024,"y":0},{"children":[{"children":[{"alignItems":"center","children":[{"content":"VISION","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"id":"gZ7y5","letterSpacing":1.5,"name":"category","type":"text"},{"content":"2026.01.23","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":12,"fontWeight":"300","id":"8FOJT","name":"date","type":"text"}],"gap":16,"id":"BbOHC","name":"meta","type":"frame"},{"content":"一緒に奏でて、あなたの中にあるものを形にする","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":28,"fontWeight":"300","id":"5JwdE","lineHeight":1.4,"name":"title","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"content":"課題を抱える人、これから何かを始める人のための、実験的な共創の場。技術とデザインのセッションを通じて、まだ見えない可能性を引き出す。","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"WCkME","lineHeight":1.8,"name":"lead","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":16,"id":"cLqGf","layout":"vertical","name":"Article Header","type":"frame","width":"fill_container"},{"fill":"$--border","height":1,"id":"h6uIh","name":"divider","type":"frame","width":"fill_container"},{"children":[{"content":"synsk.me は、小橋俊介のポートフォリオであり、共創の入り口です。10年以上のプロダクト開発経験を通じて培った「形にする力」と「引き出す力」を、課題を抱える人・社会に向けて開いています。","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"lXFNf","lineHeight":1.8,"name":"intro","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"children":[{"content":"Problem","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":22,"fontWeight":"300","id":"eugA5","lineHeight":1.4,"name":"problemTitle","type":"text"},{"content":"「やりたいこと」や「解決したい課題」はあるけれど、どう形にすればいいかわからない。エンジニアやデザイナーに相談しても、要件がまとまっていないと話が進まない。","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"LOIop","lineHeight":1.8,"name":"problemText","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":16,"id":"Gb2fj","layout":"vertical","name":"problemSection","type":"frame","width":"fill_container"},{"children":[{"fill":"$--muted-foreground","height":"fill_container","id":"NBOQw","name":"quoteBorder","type":"frame","width":2},{"children":[{"content":"最も良いものが生まれるのは、要件が固まってからではなく、『何を作るべきか』から一緒に考えたときだということ。","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontStyle":"italic","fontWeight":"300","id":"E4Byt","lineHeight":1.8,"name":"quoteText","textGrowth":"fixed-width","type":"text","width":"fill_container"},{"content":"— 小橋俊介","fill":"$--muted-foreground","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"99rpi","name":"quoteAuthor","type":"text"}],"gap":8,"id":"ktL9Z","layout":"vertical","name":"quoteContent","type":"frame","width":"fill_container"}],"gap":16,"id":"DRMAu","name":"quote","type":"frame","width":"fill_container"},{"children":[{"content":"Solution","fill":"$--foreground","fontFamily":"Source Sans 3","fontSize":22,"fontWeight":"300","id":"66wdP","lineHeight":1.4,"name":"solutionTitle","type":"text"},{"children":[{"children":[{"content":"•","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"91keO","name":"li1Bullet","type":"text"},{"content":"対話から始める: 要件定義の前に、対話を通じて本質を探る","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"7Zz3W","lineHeight":1.6,"name":"li1Text","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":12,"id":"kFvDP","name":"li1","type":"frame","width":"fill_container"},{"children":[{"content":"•","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"1qUiq","name":"li2Bullet","type":"text"},{"content":"実験しながら見つける: 完璧を求めず、小さく作って試す","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"XgiER","lineHeight":1.6,"name":"li2Text","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":12,"id":"gW7XN","name":"li2","type":"frame","width":"fill_container"},{"children":[{"content":"•","fill":"$--muted-foreground","fontFamily":"Source Sans 3","fontSize":18,"fontWeight":"300","id":"s0vVv","name":"li3Bullet","type":"text"},{"content":"技術とデザインで具現化する: 言葉にならないものを、動くプロダクトとして形にする","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":16,"fontWeight":"300","id":"0vutq","lineHeight":1.6,"name":"li3Text","textGrowth":"fixed-width","type":"text","width":"fill_container"}],"gap":12,"id":"m0XuO","name":"li3","type":"frame","width":"fill_container"}],"gap":12,"id":"nGqCg","layout":"vertical","name":"solutionList","type":"frame","width":"fill_container"}],"gap":16,"id":"nXdZl","layout":"vertical","name":"solutionSection","type":"frame","width":"fill_container"}],"gap":24,"id":"YNL1X","layout":"vertical","name":"Article Body","type":"frame","width":"fill_container"},{"alignItems":"center","children":[{"content":"一緒に何かを始めませんか？","fill":"$--foreground","fontFamily":"Noto Sans JP","fontSize":18,"fontWeight":"300","id":"TFQyK","name":"ctaText","type":"text"},{"children":[{"content":"コンタクト","fill":"$--background","fontFamily":"Noto Sans JP","fontSize":14,"fontWeight":"300","id":"D3L2e","name":"ctaButtonText","type":"text"}],"cornerRadius":4,"fill":"$--foreground","id":"iqjou","name":"ctaButton","padding":[12,24],"type":"frame"}],"cornerRadius":8,"fill":"$--muted","gap":16,"id":"yuZ7w","layout":"vertical","name":"CTA Section","padding":32,"type":"frame","width":"fill_container"}],"fill":"$--background","gap":48,"id":"zP6s6","layout":"vertical","name":"Article Design","padding":[96,48],"type":"frame","width":720,"x":1688,"y":0}]
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,13 +115,18 @@ Typography: Source Sans 3 + Noto Sans JP, Light 300, 18px, line-height 1.8
 Spacing: 8px ベース（xs:8, sm:16, md:24, lg:48, xl:96）
 ```
 
+**トークン同期方針（決定済み）**:
+- Pencil `get_variables` API で .pen からトークン抽出可能（検証済み）
+- 同期スクリプト作成は Phase 2 実装フェーズで必要に応じて対応
+- 現時点では foundations.md をマスターとして手動同期で運用
+
 ---
 
 ### 通常フロー（Pencil検証後）
 
 1. ~~Design Tokens（グレースケール）の確定~~ ✅
 2. ~~Design Tokens（タイポグラフィ）の策定~~ ✅
-3. Design Tokens（スペーシング）の策定
+3. ~~Design Tokens（スペーシング）の策定~~ ✅
 4. `feature/redesign` ブランチを作成
 5. Phase 2 開始
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,8 +62,8 @@ Preview で確認・実験・調整
 | PRINCIPLES.md（Design） | ✅ | 余白・息づき・対話 |
 | 発信コンテンツ分析 | ✅ | docs/research/tweets-insight/, content-analysis/ |
 | Design Tokens（グレースケール） | ✅ | Neutral Gray で構造を固める |
-| Design Tokens（タイポグラフィ） | ⏳ | フォントサイズ・行間 |
-| Design Tokens（スペーシング） | ⏳ | 余白のスケール |
+| Design Tokens（タイポグラフィ） | ✅ | Source Sans 3 + Noto Sans JP, Light 300 |
+| Design Tokens（スペーシング） | ✅ | 8px ベース（xs/sm/md/lg/xl） |
 
 ### Phase 2: デザイン & 実装（反復）
 
@@ -86,8 +86,41 @@ Preview で確認・実験・調整
 
 ## 次のアクション
 
+### Pencil (Design as Code) 検証 ⏳
+
+**目的**: Figma ⇔ React連携問題をPencilで解決できるか検証し、ブログ記事化
+
+**方針決定済み**:
+- `design/foundations.pen` を作成（`docs/design/foundations.md` の進化版）
+- 説明テキスト + 視覚的例示を1ファイルに統合
+- 検証成功すれば .pen を Design の Source of Truth に
+
+**実験計画**:
+1. Design Tokens 可視化（色・Typography）
+2. Spacing 策定（視覚的に探索）
+3. コンポーネント作成（Figma→React問題の核心検証）
+
+**進捗**:
+1. [x] `design/foundations.pen` を Pencil で作成
+2. [x] Colors セクション（説明 + カラースウォッチ）
+3. [x] Typography セクション追加
+4. [x] Spacing セクション追加（使用例フレーム含む）
+5. [x] Article Design サンプル作成
+6. [ ] コンポーネント作成（Figma→React核心検証）
+
+**Design Tokens 設定値（確定済み）**:
+```
+Colors: background, foreground, muted, muted-foreground, border（Light/Dark対応）
+Typography: Source Sans 3 + Noto Sans JP, Light 300, 18px, line-height 1.8
+Spacing: 8px ベース（xs:8, sm:16, md:24, lg:48, xl:96）
+```
+
+---
+
+### 通常フロー（Pencil検証後）
+
 1. ~~Design Tokens（グレースケール）の確定~~ ✅
-2. Design Tokens（タイポグラフィ）の策定
+2. ~~Design Tokens（タイポグラフィ）の策定~~ ✅
 3. Design Tokens（スペーシング）の策定
 4. `feature/redesign` ブランチを作成
 5. Phase 2 開始

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -26,7 +26,7 @@ Components（どう）            ← 将来追加
 
 | Document | Description | Status |
 |----------|-------------|--------|
-| [foundations.md](./foundations.md) | 色・フォント・スペース | ✅ Colors, Typography / TODO Spacing |
+| [foundations.md](./foundations.md) | 色・フォント・スペース | ✅ Colors, Typography, Spacing |
 | [reference-kbkbkb.md](./reference-kbkbkb.md) | UI参考サイト分析（kbkbkb.co） | ✅ |
 | [typography-comparison.html](./typography-comparison.html) | タイポグラフィ比較（ブラウザで開く） | ✅ |
 | [font-pairing-comparison.html](./font-pairing-comparison.html) | フォントペアリング比較（ブラウザで開く） | ✅ |

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -158,17 +158,50 @@ fontFamily: {
 
 ### Design Intent
 
-[TODO: スペーシングに関する設計意図]
+**呼吸するレイアウト**: 8px ベースのスケールで、要素間に適切な余白を確保する。
+
+PRINCIPLES.md との関連:
+- **余白 over 密度**: 大きめのスペーシング（lg, xl）を積極的に使い、視覚的な余裕を生む
+- **息づき over 装飾**: 余白自体がデザイン要素。詰め込まずに呼吸させる
 
 ### Scale
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `xs` | [TODO] | [TODO] |
-| `sm` | [TODO] | [TODO] |
-| `md` | [TODO] | [TODO] |
-| `lg` | [TODO] | [TODO] |
-| `xl` | [TODO] | [TODO] |
+| `xs` | 8px | インライン要素間、アイコンとテキスト |
+| `sm` | 16px | コンポーネント内パディング |
+| `md` | 24px | カード内余白、フォーム要素間 |
+| `lg` | 48px | セクション間、大きなグループ分け |
+| `xl` | 96px | ページセクション間、ヒーロー領域 |
+
+**特徴**:
+- 8px ベース（8, 16, 24, 48, 96）で倍数関係を維持
+- lg（48px）以上を積極的に使用することで「余白 over 密度」を体現
+- Tailwind の spacing scale と互換性あり（2, 4, 6, 12, 24）
+
+### Implementation
+
+```css
+/* src/app/globals.css */
+:root {
+  --spacing-xs: 8px;
+  --spacing-sm: 16px;
+  --spacing-md: 24px;
+  --spacing-lg: 48px;
+  --spacing-xl: 96px;
+}
+```
+
+```typescript
+// tailwind.config.ts
+spacing: {
+  'xs': '8px',
+  'sm': '16px',
+  'md': '24px',
+  'lg': '48px',
+  'xl': '96px',
+}
+```
 
 ---
 
@@ -192,3 +225,4 @@ fontFamily: {
 | 2026-01-27 | 0.1.0 | 初期構造作成 |
 | 2026-01-27 | 0.2.0 | グレースケール（Neutral Gray）確定、モノクロファーストアプローチ明記 |
 | 2026-01-29 | 0.3.0 | Typography 確定: Source Sans 3 + Noto Sans JP, Light 300 ベース |
+| 2026-01-29 | 0.4.0 | Spacing 確定: 8px ベース（xs/sm/md/lg/xl） |


### PR DESCRIPTION
## Summary
- Pencil (Design as Code) 検証として `design/foundations.pen` を作成
- Design Tokens（変数）を設定: Colors（Light/Dark テーマ対応）、Typography、Spacing
- Colors セクション: グレースケールパレットの視覚化（Light/Dark 両モード）
- Typography セクション: フォント情報（Source Sans 3 / Noto Sans JP）、Type Scale サンプル
- Spacing セクション: 8px ベーススケール（xs/sm/md/lg/xl）と使用例
- Article Design サンプル: VISION.md コンテンツを使用した実践的レイアウト

## Changes (after code review)
- CLAUDE.md: フォント表記を `Source Sans 3 + Noto Sans JP` に更新
- ROADMAP.md: Spacing ステータスを完了に更新
- ROADMAP.md: トークン同期方針を追記（`get_variables` API 検証済み）

## Test plan
- [x] Pencil エディタで `design/foundations.pen` を開いて表示確認
- [x] Light/Dark モードのカラースウォッチが正しく表示されること
- [x] Typography サンプルが正しいフォント・サイズで表示されること
- [x] Spacing スケールが正しい幅で可視化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)